### PR TITLE
Port to 1.21.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ loom {
 }
 
 repositories {
-	maven { url "https://maven.shedaniel.me/" }
-	maven { url "https://maven.terraformersmc.com/" }
+	maven { url = "https://maven.shedaniel.me/" }
+	maven { url = "https://maven.terraformersmc.com/" }
 	exclusiveContent {
 		forRepository {
 			maven {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.nio.file.*
 import java.nio.file.attribute.BasicFileAttributes
 
 plugins {
-	id 'fabric-loom' version '1.9-SNAPSHOT'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 	id 'maven-publish'
 	id 'com.matthewprenger.cursegradle' version '1.4.0'
 	id 'com.modrinth.minotaur' version '2.+'

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,26 +3,26 @@ org.gradle.warning.mode=all
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.2
-loader_version=0.16.9
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
+loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.4.4
+mod_version=1.4.5
 maven_group=com.lizin5ths
 archives_base_name=indypets
 
 # Dependencies
 java_version=21
-fabric_version=0.112.2+1.21.4
-cloth_config_version=17.0.144
-modmenu_version=13.0.0-beta.1
+fabric_version=0.119.5+1.21.5
+cloth_config_version=18.0.145
+modmenu_version=14.0.0-rc.2
 
 modrinth_id=SVJhmJvx
 curseforge_id=320967
 minepkg_id=indypets
-game_version_range=1.21.4
-game_version_list=1.21.4
+game_version_range=>=1.21.5
+game_version_list=1.21.5
 modrinth_dependencies=P7dR8mSH, 9s6osm5g
 curseforge_dependencies=fabric-api, cloth-config
 minepkg_dependencies=fabric, cloth-config

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ modmenu_version=13.0.0-beta.1
 modrinth_id=SVJhmJvx
 curseforge_id=320967
 minepkg_id=indypets
-game_version_range=>=1.21.4
+game_version_range=1.21.4
 game_version_list=1.21.4
 modrinth_dependencies=P7dR8mSH, 9s6osm5g
 curseforge_dependencies=fabric-api, cloth-config

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/lizin5ths/indypets/IndyPetsClient.java
+++ b/src/main/java/com/lizin5ths/indypets/IndyPetsClient.java
@@ -27,7 +27,7 @@ public class IndyPetsClient implements ClientModInitializer {
 
 	public static void playLocalPlayerSound(PlayerEntity player, SoundEvent soundEvent, boolean positioned) {
 		if (positioned) {
-			player.getWorld().playSound((Entity) null, player.getX(), player.getY(), player.getZ(), soundEvent, player.getSoundCategory(), 1.0F, 1.0F);
+			player.getWorld().playSoundClient(player.getX(), player.getY(), player.getZ(), soundEvent, player.getSoundCategory(), 1.0F, 1.0F, false);
 		} else {
 			// non-positioned sound (just like music, but with players category)
 			SoundInstance sound = new PositionedSoundInstance(soundEvent.id(), SoundCategory.PLAYERS,

--- a/src/main/java/com/lizin5ths/indypets/IndyPetsClient.java
+++ b/src/main/java/com/lizin5ths/indypets/IndyPetsClient.java
@@ -7,6 +7,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.client.sound.SoundInstance;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -26,7 +27,7 @@ public class IndyPetsClient implements ClientModInitializer {
 
 	public static void playLocalPlayerSound(PlayerEntity player, SoundEvent soundEvent, boolean positioned) {
 		if (positioned) {
-			player.getWorld().playSound(player.getX(), player.getY(), player.getZ(), soundEvent, player.getSoundCategory(), 1.0F, 1.0F, true);
+			player.getWorld().playSound((Entity) null, player.getX(), player.getY(), player.getZ(), soundEvent, player.getSoundCategory(), 1.0F, 1.0F);
 		} else {
 			// non-positioned sound (just like music, but with players category)
 			SoundInstance sound = new PositionedSoundInstance(soundEvent.id(), SoundCategory.PLAYERS,

--- a/src/main/java/com/lizin5ths/indypets/config/ServerConfig.java
+++ b/src/main/java/com/lizin5ths/indypets/config/ServerConfig.java
@@ -1,5 +1,7 @@
 package com.lizin5ths.indypets.config;
 
+import net.minecraft.entity.LazyEntityReference;
+import net.minecraft.entity.LivingEntity;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
@@ -19,5 +21,12 @@ public class ServerConfig {
 
 		// default to server config
 		return Config.local();
+	}
+
+	public static Config getDefaultedPlayerConfig(LazyEntityReference<LivingEntity> player) {
+		if (player == null){
+			return getDefaultedPlayerConfig((UUID) null);
+		}
+		return getDefaultedPlayerConfig(player.getUuid());
 	}
 }

--- a/src/main/java/com/lizin5ths/indypets/mixin/TameableEntityMixin.java
+++ b/src/main/java/com/lizin5ths/indypets/mixin/TameableEntityMixin.java
@@ -28,7 +28,7 @@ public abstract class TameableEntityMixin extends AnimalEntity implements Indepe
 		super(entityType, world);
 	}
 
-	@Inject(method = "setOwnerUuid", at = @At(value = "TAIL"))
+	@Inject(method = "setOwner", at = @At(value = "TAIL"))
 	protected void indypets$initFollowData(CallbackInfo ci) {
 		if (getWorld().isClient())
 			return;
@@ -59,11 +59,11 @@ public abstract class TameableEntityMixin extends AnimalEntity implements Indepe
 
 	@Inject(method = "readCustomDataFromNbt", at = @At("TAIL"))
 	private void indypets$readFollowDataFromNbt(NbtCompound nbt, CallbackInfo callbackInfo) {
-		indypets$isIndependent = !nbt.getBoolean("AllowedToFollow");
+		indypets$isIndependent = !nbt.getBoolean("AllowedToFollow").orElse(false);
 
-		if (nbt.contains("IndyPets$HomePos", NbtElement.LIST_TYPE)) {
-			NbtList nbtList = nbt.getList("IndyPets$HomePos", NbtElement.INT_TYPE);
-			indypets$homePos = new BlockPos(nbtList.getInt(0), nbtList.getInt(1), nbtList.getInt(2));
+		if (nbt.contains("IndyPets$HomePos")) {
+			NbtList nbtList = nbt.getList("IndyPets$HomePos").get();
+			indypets$homePos = new BlockPos(nbtList.getInt(0).get(), nbtList.getInt(1).get(), nbtList.getInt(2).get());
 		} else if (isTamed()) {
 			indypets$setHome(); // fallback
 		}

--- a/src/main/java/com/lizin5ths/indypets/mixin/TameableEntityMixin.java
+++ b/src/main/java/com/lizin5ths/indypets/mixin/TameableEntityMixin.java
@@ -1,6 +1,7 @@
 package com.lizin5ths.indypets.mixin;
 
 import com.lizin5ths.indypets.util.Independence;
+import java.util.Optional;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.passive.TameableEntity;
@@ -62,8 +63,11 @@ public abstract class TameableEntityMixin extends AnimalEntity implements Indepe
 		indypets$isIndependent = !nbt.getBoolean("AllowedToFollow").orElse(false);
 
 		if (nbt.contains("IndyPets$HomePos")) {
-			NbtList nbtList = nbt.getList("IndyPets$HomePos").get();
-			indypets$homePos = new BlockPos(nbtList.getInt(0).get(), nbtList.getInt(1).get(), nbtList.getInt(2).get());
+			Optional<NbtList> nbtList = nbt.getList("IndyPets$HomePos");
+			if (nbtList.isPresent()) {
+				NbtList homePos = nbtList.get();
+				indypets$homePos = new BlockPos(homePos.getInt(0).orElseThrow(), homePos.getInt(1).orElseThrow(), homePos.getInt(2).orElseThrow());
+			}
 		} else if (isTamed()) {
 			indypets$setHome(); // fallback
 		}

--- a/src/main/java/com/lizin5ths/indypets/util/IndyPetsUtil.java
+++ b/src/main/java/com/lizin5ths/indypets/util/IndyPetsUtil.java
@@ -56,13 +56,13 @@ public class IndyPetsUtil {
 		if (!tameable.isTamed())
 			return false;
 
-		Config config = ServerConfig.getDefaultedPlayerConfig(tameable.getOwnerUuid());
+		Config config = ServerConfig.getDefaultedPlayerConfig(tameable.getOwnerReference().getUuid());
 		return !config.blocklist.isBlocked(EntityType.getId(tameable.getType()));
 	}
 
 	/** Whether the player can change the independence of the entity */
 	public static boolean canInteract(ServerPlayerEntity player, @Nullable Entity entity) {
-		return isActive(entity) && player.getUuid().equals(((TameableEntity) entity).getOwnerUuid());
+		return isActive(entity) && ((TameableEntity) entity).isOwner(player);
 	}
 
 	public static void toggleIndependence(TameableEntity tameable) {
@@ -153,7 +153,7 @@ public class IndyPetsUtil {
 		// distance to home
 		float d = (float) Math.sqrt(tameable.getBlockPos().getSquaredDistance(getHomePos(tameable)));
 
-		Config config = ServerConfig.getDefaultedPlayerConfig(tameable.getOwnerUuid());
+		Config config = ServerConfig.getDefaultedPlayerConfig(tameable.getOwnerReference().getUuid());
 		float start = config.homeRadius * config.innerHomePercentage;
 		float end   = config.homeRadius;
 

--- a/src/main/java/com/lizin5ths/indypets/util/IndyPetsUtil.java
+++ b/src/main/java/com/lizin5ths/indypets/util/IndyPetsUtil.java
@@ -56,7 +56,7 @@ public class IndyPetsUtil {
 		if (!tameable.isTamed())
 			return false;
 
-		Config config = ServerConfig.getDefaultedPlayerConfig(tameable.getOwnerReference().getUuid());
+		Config config = ServerConfig.getDefaultedPlayerConfig(tameable.getOwnerReference());
 		return !config.blocklist.isBlocked(EntityType.getId(tameable.getType()));
 	}
 
@@ -153,7 +153,7 @@ public class IndyPetsUtil {
 		// distance to home
 		float d = (float) Math.sqrt(tameable.getBlockPos().getSquaredDistance(getHomePos(tameable)));
 
-		Config config = ServerConfig.getDefaultedPlayerConfig(tameable.getOwnerReference().getUuid());
+		Config config = ServerConfig.getDefaultedPlayerConfig(tameable.getOwnerReference());
 		float start = config.homeRadius * config.innerHomePercentage;
 		float end   = config.homeRadius;
 


### PR DESCRIPTION
The changes in this PR allowed me to build IndyPets and run it against a clean 1.21.5 instance.

Things I tested:
- [x] after summoning an untamed cat, I tamed it, set it to independent and flew away. It did not follow me
- [x] teleporting to my cat, I set it to following me, flew away and saw it teleporting towards me
- [x] exiting the world and logging back in, the cat remembers whether it should teleport to me
- [x] exiting the world, logging back in and running `/data get entity @n[type=cat]` includes the field `IndyPets$HomePos`
- [x] shutting down Minecraft and logging into the world as a different player, I cannot interact with the cat (including changing its IndyPets state)

That said: please do your own testing and let me know if I messed up anything (I was absolutely following my nose with those NBT compound changes).
