### PR TITLE
(WIP) Update mod to 1.21.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,9 @@ dependencies {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 
-	modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}") {
-		exclude(group: "net.fabricmc.fabric-api")
-	}
+//	modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}") {
+//		exclude(group: "net.fabricmc.fabric-api")
+//	}
 
 //	modRuntimeOnly "maven.modrinth:friends-and-foes:fabric-mc1.21.1-3.0.3"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.warning.mode=all
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.10
+minecraft_version=1.21.6-rc1
+yarn_mappings=1.21.6-rc1+build.1
+loader_version=0.16.14
 
 # Mod Properties
 mod_version=1.4.7
@@ -14,15 +14,15 @@ archives_base_name=indypets
 
 # Dependencies
 java_version=21
-fabric_version=0.119.5+1.21.5
+fabric_version=0.126.1+1.21.6
 cloth_config_version=18.0.145
 modmenu_version=14.0.0-rc.2
 
 modrinth_id=SVJhmJvx
 curseforge_id=320967
 minepkg_id=indypets
-game_version_range=1.21.5
-game_version_list=1.21.5
+game_version_range=>1.21.5
+game_version_list=1.21.6
 modrinth_dependencies=P7dR8mSH, 9s6osm5g
 curseforge_dependencies=fabric-api, cloth-config
 minepkg_dependencies=fabric, cloth-config

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ modmenu_version=14.0.0-rc.2
 modrinth_id=SVJhmJvx
 curseforge_id=320967
 minepkg_id=indypets
-game_version_range=>=1.21.5
+game_version_range=1.21.5
 game_version_list=1.21.5
 modrinth_dependencies=P7dR8mSH, 9s6osm5g
 curseforge_dependencies=fabric-api, cloth-config

--- a/src/main/java/com/lizin5ths/indypets/client/Keybindings.java
+++ b/src/main/java/com/lizin5ths/indypets/client/Keybindings.java
@@ -86,10 +86,10 @@ public class Keybindings {
 			}
 
 			if (shouldWhistle) {
-				client.getNetworkHandler().sendCommand("indypets whistle");
+				client.getNetworkHandler().sendChatCommand("indypets whistle");
 				IndyPetsClient.playLocalPlayerSound(client.player, WHISTLE, Config.local().positionedWhistleSound);
 			} else {
-				client.getNetworkHandler().sendCommand("indypets unwhistle");
+				client.getNetworkHandler().sendChatCommand("indypets unwhistle");
 				IndyPetsClient.playLocalPlayerSound(client.player, UNWHISTLE, Config.local().positionedWhistleSound);
 			}
 		});

--- a/src/main/java/com/lizin5ths/indypets/config/client/ConfigScreen.java
+++ b/src/main/java/com/lizin5ths/indypets/config/client/ConfigScreen.java
@@ -1,13 +1,13 @@
 package com.lizin5ths.indypets.config.client;
 
 import com.lizin5ths.indypets.config.Config;
-import com.terraformersmc.modmenu.api.ConfigScreenFactory;
-import com.terraformersmc.modmenu.api.ModMenuApi;
-import me.shedaniel.autoconfig.AutoConfig;
-
-public class ConfigScreen implements ModMenuApi {
-	@Override
-	public ConfigScreenFactory<?> getModConfigScreenFactory() {
-		return parent -> AutoConfig.getConfigScreen(Config.class, parent).get();
-	}
-}
+//import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+//import com.terraformersmc.modmenu.api.ModMenuApi;
+//import me.shedaniel.autoconfig.AutoConfig;
+//
+//public class ConfigScreen implements ModMenuApi {
+//	@Override
+//	public ConfigScreenFactory<?> getModConfigScreenFactory() {
+//		return parent -> AutoConfig.getConfigScreen(Config.class, parent).get();
+//	}
+//}

--- a/src/main/java/com/lizin5ths/indypets/mixin/MobEntityMixin.java
+++ b/src/main/java/com/lizin5ths/indypets/mixin/MobEntityMixin.java
@@ -47,7 +47,7 @@ public abstract class MobEntityMixin extends LivingEntity {
 					cir.setReturnValue(ActionResult.SUCCESS);
 				}
 			} else {
-				Config config = ServerConfig.getDefaultedPlayerConfig(player.getUuid());
+				com.lizin5ths.indypets.config.Config config = ServerConfig.getDefaultedPlayerConfig(player.getUuid());
 				if (config.regularInteract) {
 					// continue in method below
 					isInteracting.set(true);

--- a/src/main/java/com/lizin5ths/indypets/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/lizin5ths/indypets/mixin/ServerPlayerEntityMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin extends PlayerEntity {
 	public ServerPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
-		super(world, pos, yaw, gameProfile);
+		super(world, gameProfile);
 	}
 
 	@Inject(method = "onDisconnect", at = @At("TAIL"))

--- a/src/main/java/com/lizin5ths/indypets/util/IndyPetsUtil.java
+++ b/src/main/java/com/lizin5ths/indypets/util/IndyPetsUtil.java
@@ -84,11 +84,11 @@ public class IndyPetsUtil {
 			sendPetStatusMessage(player, tameable, singlePet);
 		} else {
 			if (isIndependent(tameable)) {
-				player.getServerWorld().spawnParticles(player, ParticleTypes.ANGRY_VILLAGER, true, true,
+				player.getWorld().spawnParticles(player, ParticleTypes.ANGRY_VILLAGER, true, true,
 					tameable.getX(), tameable.getBodyY(0.5), tameable.getZ(),
 					7, 0.4, 0.4, 0.4, 0.3);
 			} else {
-				player.getServerWorld().spawnParticles(player, ParticleTypes.HAPPY_VILLAGER, true, true,
+				player.getWorld().spawnParticles(player, ParticleTypes.HAPPY_VILLAGER, true, true,
 					tameable.getX(), tameable.getBodyY(0.5), tameable.getZ(),
 					11, 0.5, 0.5, 0.5, 2);
 			}


### PR DESCRIPTION
I'm opening this PR to give you a leg up on porting the mod to 1.21.6. It probably should not be merged as written, due to the following:

- The `game_version_range` should probably be set to ">=1.21.6" after Tuesday. Before then, the best I could do while keeping the mod testable with the RC1 was set it to ">1.21.5"
  - Note that, as per your prior feedback, I've made f28637b10b7711cccfbf4b01a38d541d0701f947 to explicitly go on the 1.21.5 branch
- ModMenu currently has no builds for 1.21.6 (and the 1.21.5 builds are incompatible), so I've had to disable the ModMenu integration
- While the mod does appear to work as expected on a new 1.21.6 world, and _I believe_ legacy HomePos values unmarshal correctly (a `BlockPos` extends `Vec3i` and thus _should_ be a three-element int array):
  1. I haven't thoroughly tested this
  1. I'm not sure whether you'd prefer to switch to using [the new vanilla  `home_pos` and `home_radius` attributes](https://www.minecraft.net/en-us/article/minecraft-snapshot-25w18a)